### PR TITLE
Add import functionality and enhance error handling in Minecraft-Script

### DIFF
--- a/documentation/syntax.md
+++ b/documentation/syntax.md
@@ -46,6 +46,42 @@ var text = "Hello World!";
 ```
 
 
+### Imports
+Imports load code from another `.mcs` file. Import paths are resolved relative
+to the file that contains the import statement.
+
+Inline imports make the imported file's top-level functions and variables
+available as if the imported statements were written in the current file.
+
+#### Grammar
+- "import" [string]
+- "import" [string] "as" [name]
+
+#### Grammatical class: Statement
+
+#### Examples
+```js
+import "./helpers.mcs";
+
+function init() {
+    helper_function();
+}
+```
+
+Aliased imports keep the imported file in a module namespace.
+
+```js
+import "./helpers.mcs" as helpers;
+
+function init() {
+    helpers.helper_function();
+}
+```
+
+Import cycles are not allowed. If file A imports file B, file B cannot import
+file A again.
+
+
 
 ## Variables
 

--- a/examples/imports_helper.mcs
+++ b/examples/imports_helper.mcs
@@ -1,0 +1,9 @@
+var helper_prefix = "Imported helper";
+
+function announce_inline() {
+    log(helper_prefix, "loaded through an inline import");
+}
+
+function announce_alias() {
+    log(helper_prefix, "loaded through an aliased import");
+}

--- a/examples/imports_main.mcs
+++ b/examples/imports_main.mcs
@@ -1,0 +1,11 @@
+import "./imports_helper.mcs";
+import "./imports_helper.mcs" as helper;
+
+function init() {
+    announce_inline();
+    helper.announce_alias();
+}
+
+function main() {
+    command("# imports demo tick placeholder");
+}

--- a/minecraft_script/__init__.py
+++ b/minecraft_script/__init__.py
@@ -1,15 +1,19 @@
 from .lexer.lexer import Lexer
 from .parser.parser import Parser
 from .interpreter.interpreter import Interpreter, InterpreterContext, SymbolTable
+from .imports import parse_code_with_imports
 
 
-def debug_code(code_input: str, *, print_variables: bool = False) -> None:
-    lexer = Lexer(code_input)
-    parser = Parser(lexer.tokenize())
-
+def debug_code(
+    code_input: str,
+    *,
+    print_variables: bool = False,
+    source_path=None,
+    import_base_dir=None,
+) -> None:
     interpreter = Interpreter()
     context = InterpreterContext(top_level=True)
-    interpreter.visit(parser.parse(), context)
+    interpreter.visit(parse_code(code_input, source_path=source_path, import_base_dir=import_base_dir), context)
 
     if print_variables:
         print(context.symbol_table.symbols)
@@ -35,11 +39,5 @@ def run_shell():
         print(run_interpreter.visit(ast, context))
 
 
-def parse_code(code: str):
-    run_lexer = Lexer(code + "\n")
-    tokens = run_lexer.tokenize()
-
-    run_parser = Parser(tokens)
-    ast = run_parser.parse()
-
-    return ast
+def parse_code(code: str, *, source_path=None, import_base_dir=None):
+    return parse_code_with_imports(code, source_path=source_path, import_base_dir=import_base_dir)

--- a/minecraft_script/compiler/__init__.py
+++ b/minecraft_script/compiler/__init__.py
@@ -1,7 +1,17 @@
+from pathlib import Path
+
 from .. import parse_code
 from .compiler import Compiler
 
 
-def build_datapack(code: str, datapack_name: str, output_path: str, verbose: bool = False) -> None:
-    ast = parse_code(code)
+def build_datapack(
+    code: str,
+    datapack_name: str,
+    output_path: str,
+    verbose: bool = False,
+    *,
+    source_path: str | Path | None = None,
+    import_base_dir: str | Path | None = None,
+) -> None:
+    ast = parse_code(code, source_path=source_path, import_base_dir=import_base_dir)
     Compiler(ast, datapack_name, output_path, verbose).build()

--- a/minecraft_script/compiler/compile_interpreter.py
+++ b/minecraft_script/compiler/compile_interpreter.py
@@ -58,12 +58,25 @@ class CompileSymbols:
         return f'CompileSymbols({self.parent !r})'
 
 class CompileContext:
-    def __init__(self, mcfunction_name: str = None, *, parent: "CompileContext" = None, top_level: bool = False):
+    def __init__(
+        self,
+        mcfunction_name: str = None,
+        *,
+        parent: "CompileContext" = None,
+        top_level: bool = False,
+        function_prefix: str = None,
+    ):
         self.parent: CompileContext = parent
         self.symbols = CompileSymbols(parent.symbols if parent is not None else None, load_builtins=top_level)
         self.top_level = top_level
         self._mcfunction_name = mcfunction_name if mcfunction_name is not None else f":cb_{generate_uuid()}"
         self.uuid = generate_uuid()
+        self.function_prefix = (
+            function_prefix.rstrip("/")
+            if function_prefix is not None else
+            parent.function_prefix if parent is not None else
+            ""
+        )
     @property
     def mcfunction_name(self) -> str:
         return (
@@ -77,6 +90,8 @@ class CompileContext:
         return self.symbols.set(name, value)
     def declare(self, name: str, value: mcs_type) -> None:
         self.symbols.declare(name, value)
+    def get_function_name(self, name: str) -> str:
+        return f"{self.function_prefix}/{name}" if self.function_prefix else name
     def get_context_ownership(self, var_name: str) -> "CompileContext":
         if self.symbols.symbols.get(var_name, None) is not None:
             return self
@@ -190,7 +205,7 @@ class CompileInterpreter:
                 raise ValueError(f"Event function {fnc_name!r} cannot have parameters")
             if SCOREBOARD_CRITERIA_PATTERN.fullmatch(event_criteria) is None:
                 raise ValueError(f"Invalid scoreboard criteria {event_criteria!r}")
-        function = MCSFunction(fnc_name, fnc_body, fnc_parameter_names, context, event_criteria)
+        function = MCSFunction(context.get_function_name(fnc_name), fnc_body, fnc_parameter_names, context, event_criteria)
         self.functions_to_generate.add(function)
         if event_criteria is not None:
             self.scoreboard_event_functions.append(function)
@@ -427,6 +442,20 @@ class CompileInterpreter:
         commands = add_comment(commands, f"Code block (parent: {context.mcfunction_name !r})")
         self.add_commands(context.mcfunction_name, commands)
         return return_value
+    def visit_ImportNode(self, node, context: CompileContext) -> CompileResult:
+        alias = node.get_alias()
+        if alias is None:
+            raise ValueError("Inline imports should be resolved before compilation")
+
+        module_context = CompileContext(
+            f"imports/{alias}/__init",
+            parent=context,
+            function_prefix=f"imports/{alias}",
+        )
+        self.visit(node.get_body(), module_context)
+        context.declare(alias, MCSModule(alias, module_context))
+        self.add_command(context.mcfunction_name, f"function {self.datapack_id}:{module_context.mcfunction_name}")
+        return CompileResult()
     def visit_FunctionCallNode(self, node, context: CompileContext) -> CompileResult:
         fnc: MCSFunction = self.visit(node.get_root(), context).get_value()
         arguments: tuple[mcs_type, ...] = tuple(map(lambda x: self.visit(x, context).get_value(), node.get_arguments()))

--- a/minecraft_script/compiler/compile_types.py
+++ b/minecraft_script/compiler/compile_types.py
@@ -221,6 +221,25 @@ class MCSFunction:
         return f"MCSFunction({self.name !r})"
 
 
+class MCSModule:
+    def __init__(self, name: str, context):
+        self.name = name
+        self.context = context
+
+    def __getattr__(self, name: str):
+        if not name.startswith("attribute_"):
+            raise AttributeError(name)
+
+        attribute_name = name[len("attribute_"):]
+        return lambda: self.context.get(attribute_name)
+
+    def class_name(self) -> str:
+        return "Module"
+
+    def __repr__(self) -> str:
+        return f"MCSModule({self.name !r})"
+
+
 mcs_type = (
     MCSNull
     | MCSNumber
@@ -229,6 +248,7 @@ mcs_type = (
     | MCSUnknown
     | MCSList
     | MCSFunction
+    | MCSModule
     | MCSVariable
     | MCSTextComponent
 )

--- a/minecraft_script/errors.py
+++ b/minecraft_script/errors.py
@@ -40,6 +40,11 @@ class MCSParserError(Exception):
         super().__init__(details)
 
 
+class MCSImportError(Exception):
+    def __init__(self, details):
+        super().__init__(details)
+
+
 class MCSInterpreterError(NotImplementedError):
     def __init__(self, details):
         super().__init__(details)

--- a/minecraft_script/imports.py
+++ b/minecraft_script/imports.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .errors import MCSImportError
+from .lexer.lexer import Lexer
+from .parser.nodes import ImportNode, MultilineCodeNode
+from .parser.parser import Parser
+
+
+def parse_code_with_imports(
+    code: str,
+    *,
+    source_path: str | Path | None = None,
+    import_base_dir: str | Path | None = None,
+):
+    ast = _parse_raw(code)
+    if source_path is None and import_base_dir is None:
+        return _resolve_imports(ast, None, None, [])
+
+    resolved_source_path = Path(source_path).resolve() if source_path is not None else None
+    resolved_base_dir = Path(import_base_dir).resolve() if import_base_dir is not None else None
+    if resolved_base_dir is None and resolved_source_path is not None:
+        resolved_base_dir = resolved_source_path.parent
+
+    stack = [resolved_source_path] if resolved_source_path is not None else []
+    return _resolve_imports(ast, resolved_source_path, resolved_base_dir, stack)
+
+
+def _parse_raw(code: str):
+    lexer = Lexer(code + "\n")
+    parser = Parser(lexer.tokenize())
+    return parser.parse()
+
+
+def _resolve_imports(
+    node,
+    source_path: Path | None,
+    import_base_dir: Path | None,
+    stack: list[Path],
+):
+    if not isinstance(node, MultilineCodeNode):
+        return node
+
+    resolved_nodes = []
+    for statement in node.get_nodes():
+        if not isinstance(statement, ImportNode):
+            resolved_nodes.append(statement)
+            continue
+
+        imported_path = _resolve_import_path(statement.get_path(), source_path, import_base_dir)
+        imported_body = _load_imported_body(imported_path, stack)
+
+        if statement.get_alias() is None:
+            resolved_nodes.extend(imported_body.get_nodes())
+        else:
+            resolved_nodes.append(statement.with_body(imported_body))
+
+    return MultilineCodeNode(tuple(resolved_nodes), node.get_position())
+
+
+def _resolve_import_path(import_path: str, source_path: Path | None, import_base_dir: Path | None) -> Path:
+    path = Path(import_path)
+    if path.is_absolute():
+        return path.resolve()
+
+    base_dir = source_path.parent if source_path is not None else import_base_dir
+    if base_dir is None:
+        raise MCSImportError(
+            f"Cannot resolve relative import {import_path!r} without source_path or import_base_dir"
+        )
+    return (base_dir / path).resolve()
+
+
+def _load_imported_body(imported_path: Path, stack: list[Path]):
+    if not imported_path.is_file():
+        raise MCSImportError(f"Could not find import file {str(imported_path)!r}")
+
+    if imported_path in stack:
+        cycle = " -> ".join(str(path) for path in (*stack, imported_path))
+        raise MCSImportError(f"Circular import detected: {cycle}")
+
+    code = imported_path.read_text(encoding="utf-8")
+    ast = _parse_raw(code)
+    return _resolve_imports(ast, imported_path, imported_path.parent, [*stack, imported_path])

--- a/minecraft_script/interpreter/interpreter.py
+++ b/minecraft_script/interpreter/interpreter.py
@@ -185,11 +185,21 @@ class Interpreter:
         body = node.get_body()
         parameter_names: list[str, ...] = node.get_parameter_names()
 
-        function = MCSFunction(name, body, tuple(parameter_names))
+        function = MCSFunction(name, body, tuple(parameter_names), context)
 
         if name is not None:
             context.declare(name, function)
 
+        return RuntimeResult()
+
+    def visit_ImportNode(self, node, context: InterpreterContext) -> RuntimeResult:
+        alias = node.get_alias()
+        if alias is None:
+            raise MCSImportError("Inline imports should be resolved before interpretation")
+
+        module_context = InterpreterContext(parent=context)
+        self.visit(node.get_body(), module_context)
+        context.declare(alias, MCSModule(alias, module_context))
         return RuntimeResult()
 
     def visit_FunctionCallNode(self, node, context: InterpreterContext) -> RuntimeResult:

--- a/minecraft_script/interpreter/types.py
+++ b/minecraft_script/interpreter/types.py
@@ -350,6 +350,31 @@ class MCSTextComponent(MCSObject):
         return self._bind("hover_item", _runtime_hover_item)
 
 
+class MCSModule(MCSObject):
+    def __init__(self, name: str, context):
+        self.name = name
+        self.context = context
+
+    def get_value(self):
+        raise MCSInterpreterError("Can't get value of module")
+
+    def print_value(self) -> str:
+        return f"<module-{self.name}>"
+
+    def repr_value(self) -> str:
+        return self.print_value()
+
+    def __getattr__(self, name: str):
+        if not name.startswith("attribute_"):
+            raise AttributeError(name)
+
+        attribute_name = name[len("attribute_"):]
+        return lambda: self.context.get(attribute_name)
+
+    def __repr__(self) -> str:
+        return f"MCSModule({self.name !r})"
+
+
 def _runtime_require_string(args, method_name: str) -> MCSString:
     if len(args) != 1 or not isinstance(args[0], MCSString):
         raise MCSTypeError(f"TextComponent.{method_name}() expects one string argument")
@@ -448,10 +473,11 @@ def _runtime_hover_item(receiver: MCSTextComponent, args) -> MCSTextComponent:
 
 
 class MCSFunction(MCSObject):
-    def __init__(self, name: str, body, parameter_names: tuple[str, ...]):
+    def __init__(self, name: str, body, parameter_names: tuple[str, ...], context=None):
         self.name = name if name is not None else "anonymous function"
         self.body = body
         self.parameter_names = parameter_names
+        self.context = context
 
     def get_value(self):
         raise MCSInterpreterError("Can't get value of function")
@@ -465,7 +491,7 @@ class MCSFunction(MCSObject):
     def call(self, arg_list: list | None, context):
         from .interpreter import Interpreter, InterpreterContext, RuntimeResult
         local_interpreter = Interpreter()
-        local_context = InterpreterContext(parent=context)  # top level always false here
+        local_context = InterpreterContext(parent=self.context or context)  # top level always false here
 
         if len(arg_list) != len(self.parameter_names):
             raise MCSValueError(f"Function {self.print_value()} takes {len(self.parameter_names)} arguments, got {len(arg_list)}")

--- a/minecraft_script/lexer/grammar/LANG_KEYWORDS.json
+++ b/minecraft_script/lexer/grammar/LANG_KEYWORDS.json
@@ -14,6 +14,8 @@
   "function" : "TT_FUNC_DEFINE",
   "on"       : "TT_ON",
   "return"   : "TT_RETURN",
+  "import"   : "TT_IMPORT",
+  "as"       : "TT_AS",
 
   "true"     : "TT_BOOLEAN",
   "false"    : "TT_BOOLEAN",

--- a/minecraft_script/parser/nodes.py
+++ b/minecraft_script/parser/nodes.py
@@ -395,6 +395,32 @@ class AttributeGetNode(ParserNode):
         return f"AttributeGetNode({self.root !r}, {self.name !r})"
 
 
+class ImportNode(ParserNode):
+    def __init__(self, path: Token, alias: Token = None, position: tuple[int, int] = None, body: ParserNode = None):
+        self.path = path
+        self.alias = alias
+        self.position = position if position is not None else path.get_position()
+        self.body = body
+
+    def get_path(self) -> str:
+        return self.path.value
+
+    def get_alias(self) -> str | None:
+        return self.alias.value if self.alias is not None else None
+
+    def get_body(self) -> ParserNode | None:
+        return self.body
+
+    def with_body(self, body: ParserNode) -> "ImportNode":
+        return ImportNode(self.path, self.alias, self.position, body)
+
+    def get_position(self) -> tuple[int, int]:
+        return self.position
+
+    def __repr__(self) -> str:
+        return f"ImportNode({self.path !r}, {self.alias !r}, {self.position !r}, {self.body !r})"
+
+
 class EntitySelectorNode(ParserNode):
     def __init__(self, selector: str, statement: ParserNode, position: tuple[int, int]):
         self.selector = selector

--- a/minecraft_script/parser/parser.py
+++ b/minecraft_script/parser/parser.py
@@ -156,6 +156,9 @@ class Parser:
         elif self.current_token.matches('TT_RETURN'):
             return self.return_statement()
 
+        elif self.current_token.matches('TT_IMPORT'):
+            return self.import_statement()
+
         elif self.current_token.matches('TT_IF_CONDITIONAL'):
             return self.if_condition()
 
@@ -321,6 +324,25 @@ class Parser:
             return ReturnNode(None, position)  # don't advance since newline is part of statement
         else:
             return ReturnNode(self.expression(), position)
+
+    def import_statement(self) -> ImportNode:
+        position = self.current_token.get_position()
+        self.advance()
+
+        if not self.current_token.matches('TT_STRING'):
+            self.raise_error(f"Expected import path string, got {self.current_token.value !r}")
+        path = self.current_token
+        self.advance()
+
+        alias = None
+        if self.current_token.matches('TT_AS'):
+            self.advance()
+            if not self.current_token.matches('TT_NAME'):
+                self.raise_error(f"Expected import alias name, got {self.current_token.value !r}")
+            alias = self.current_token
+            self.advance()
+
+        return ImportNode(path, alias, position)
 
     def code_block(self, *, insert_newline: bool = True) -> CodeBlockNode:
         position = self.current_token.get_position()

--- a/minecraft_script/shell_commands.py
+++ b/minecraft_script/shell_commands.py
@@ -2,6 +2,7 @@ from . import debug_code
 from .compiler import build_datapack
 from .common import COMMON_CONFIG, version
 from .config_utils import update_config, reset_config
+from pathlib import Path
 import os.path
 
 
@@ -62,10 +63,11 @@ def sh_debug(*args) -> None:
         exit()
 
     path: str = args[0]
+    source_path = Path(path).resolve()
 
-    with open(path, 'rt', encoding='utf-8') as file:
+    with open(source_path, 'rt', encoding='utf-8') as file:
         code = file.read()
-    debug_code(code)  # run code only after closing file
+    debug_code(code, source_path=source_path)  # run code only after closing file
 
 
 def sh_compile(*args) -> None:
@@ -76,6 +78,7 @@ def sh_compile(*args) -> None:
         exit()
 
     path: str = args[0]
+    source_path = Path(path).resolve()
     datapack_name: str = (
         "-".join(args[0].split("\\")[-1].split("/")[-1].split(".")[:-1]).replace("_", " ").title()
         if arg_count < 2 else
@@ -99,10 +102,10 @@ def sh_compile(*args) -> None:
         exit(-1)
 
     # Build datapack
-    with open(path, 'rt', encoding='utf-8') as mcs_file:
+    with open(source_path, 'rt', encoding='utf-8') as mcs_file:
         code = mcs_file.read()
 
-    build_datapack(code, datapack_name, output_path, verbose)
+    build_datapack(code, datapack_name, output_path, verbose, source_path=source_path)
 
 
 def sh_config(*args) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,13 @@ from tests._helpers import BUILD_TEST_ROOT, PROJECT_ROOT, CompiledDatapack
 def compile_datapack():
     compiled_roots = []
 
-    def _compile_datapack(source: str, datapack_name: str) -> CompiledDatapack:
+    def _compile_datapack(
+        source: str,
+        datapack_name: str,
+        *,
+        source_path=None,
+        import_base_dir=None,
+    ) -> CompiledDatapack:
         BUILD_TEST_ROOT.mkdir(exist_ok=True)
         datapack_root = BUILD_TEST_ROOT / datapack_name
         compiled_roots.append(datapack_root)
@@ -21,7 +27,14 @@ def compile_datapack():
             shutil.rmtree(datapack_root)
 
         try:
-            build_datapack(source, datapack_name, str(BUILD_TEST_ROOT), verbose=False)
+            build_datapack(
+                source,
+                datapack_name,
+                str(BUILD_TEST_ROOT),
+                verbose=False,
+                source_path=source_path,
+                import_base_dir=import_base_dir,
+            )
         finally:
             clear_version_context()
         return CompiledDatapack(datapack_name, datapack_root)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,167 @@
+import pytest
+
+from minecraft_script.errors import MCSImportError
+
+
+def write_mcs(path, source: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def test_inline_import_exposes_imported_functions(compile_datapack, tmp_path):
+    helper_path = write_mcs(
+        tmp_path / "helpers.mcs",
+        """
+function helper() {
+    log("inline import worked");
+}
+""",
+    )
+    main_path = write_mcs(
+        tmp_path / "main.mcs",
+        """
+import "./helpers.mcs";
+
+function init() {
+    helper();
+}
+
+function main() {
+    command("# placeholder");
+}
+""",
+    )
+
+    datapack = compile_datapack(
+        main_path.read_text(encoding="utf-8"),
+        "Test Inline Import",
+        source_path=main_path,
+    )
+
+    assert helper_path.is_file()
+    assert datapack.has_function("user_functions", "helper.mcfunction")
+    assert "function test_inline_import:user_functions/helper" in datapack.read_all_functions()
+
+
+def test_aliased_import_exposes_module_attributes(compile_datapack, tmp_path):
+    helper_path = write_mcs(
+        tmp_path / "helpers.mcs",
+        """
+var greeting = "Hello from module";
+
+function greet() {
+    log(greeting);
+}
+""",
+    )
+    main_path = write_mcs(
+        tmp_path / "main.mcs",
+        """
+import "./helpers.mcs" as helpers;
+
+function init() {
+    helpers.greet();
+}
+
+function main() {
+    command("# placeholder");
+}
+""",
+    )
+
+    datapack = compile_datapack(
+        main_path.read_text(encoding="utf-8"),
+        "Test Aliased Import",
+        source_path=main_path,
+    )
+    generated_functions = datapack.read_all_functions()
+
+    assert helper_path.is_file()
+    assert datapack.has_function("user_functions", "imports", "helpers", "__init.mcfunction")
+    assert datapack.has_function("user_functions", "imports", "helpers", "greet.mcfunction")
+    assert "function test_aliased_import:user_functions/imports/helpers/__init" in generated_functions
+    assert "function test_aliased_import:user_functions/imports/helpers/greet" in generated_functions
+
+
+def test_imports_resolve_relative_to_source_file(compile_datapack, tmp_path):
+    write_mcs(
+        tmp_path / "shared" / "helpers.mcs",
+        """
+function helper() {
+    log("relative import worked");
+}
+""",
+    )
+    main_path = write_mcs(
+        tmp_path / "packs" / "main.mcs",
+        """
+import "../shared/helpers.mcs";
+
+function init() {
+    helper();
+}
+
+function main() {
+    command("# placeholder");
+}
+""",
+    )
+
+    datapack = compile_datapack(
+        main_path.read_text(encoding="utf-8"),
+        "Test Relative Import",
+        source_path=main_path,
+    )
+
+    assert datapack.has_function("user_functions", "helper.mcfunction")
+
+
+def test_missing_import_raises_clear_error(compile_datapack, tmp_path):
+    main_path = write_mcs(
+        tmp_path / "main.mcs",
+        """
+import "./missing.mcs";
+
+function main() {
+    command("# placeholder");
+}
+""",
+    )
+
+    with pytest.raises(MCSImportError, match="Could not find import file"):
+        compile_datapack(
+            main_path.read_text(encoding="utf-8"),
+            "Test Missing Import",
+            source_path=main_path,
+        )
+
+
+def test_circular_import_raises_clear_error(compile_datapack, tmp_path):
+    first_path = write_mcs(
+        tmp_path / "first.mcs",
+        """
+import "./second.mcs";
+
+function first() {
+    log("first");
+}
+""",
+    )
+    write_mcs(
+        tmp_path / "second.mcs",
+        """
+import "./first.mcs";
+
+function second() {
+    log("second");
+}
+""",
+    )
+
+    with pytest.raises(MCSImportError, match="Circular import detected"):
+        compile_datapack(
+            first_path.read_text(encoding="utf-8"),
+            "Test Circular Import",
+            source_path=first_path,
+        )


### PR DESCRIPTION
- Introduced import statements to allow loading code from other `.mcs` files, with support for inline and aliased imports.
- Updated the parser to recognize and process import statements, including error handling for import cycles.
- Enhanced the interpreter and compiler to support module context and function name resolution for imported modules.
- Added new error classes for import-related issues to improve debugging and user feedback.
- Updated documentation to include detailed examples of import usage and syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced import system supporting inline and aliased imports with relative path resolution.
  * Implemented circular import detection with clear error messages for missing files.

* **Documentation**
  * Added comprehensive guide covering import syntax, usage patterns, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->