### PR TITLE
Add npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 build_test/
 highlighter/node_modules/
 highlighter/dist/
+npm/node_modules/
+npm/*.tgz

--- a/minecraft_script/config_utils.py
+++ b/minecraft_script/config_utils.py
@@ -1,5 +1,4 @@
 import json
-import os.path
 from pathlib import Path
 
 from .common import COMMON_CONFIG, module_folder
@@ -47,12 +46,12 @@ def config_boolean_check(value: str, setting: str) -> bool:
 
 
 def config_path_check(value: str, setting: str) -> str:
-    path = value.replace("\\", "/")
-    if not os.path.exists(path):
+    path = Path(value).expanduser().resolve()
+    if not path.exists():
         print(f"Error: path {value !r} doesn't exist for setting {setting !r}")
         exit(-1)
 
-    return path
+    return str(path)
 
 
 def config_minecraft_version_check(value: str, setting: str) -> str:

--- a/minecraft_script/shell_commands.py
+++ b/minecraft_script/shell_commands.py
@@ -4,7 +4,6 @@ from .common import COMMON_CONFIG, version
 from .config_utils import update_config, reset_config
 from .version_config import breaking_changes_between
 from pathlib import Path
-import os.path
 
 
 def handle_arguments(arguments: list):
@@ -78,35 +77,34 @@ def sh_compile(*args) -> None:
         print("No path specified to compile.")
         exit()
 
-    path: str = args[0]
-    source_path = Path(path).resolve()
+    source_path = Path(args[0]).resolve()
     datapack_name: str = (
-        "-".join(args[0].split("\\")[-1].split("/")[-1].split(".")[:-1]).replace("_", " ").title()
+        "-".join(source_path.name.split(".")[:-1]).replace("_", " ").title()
         if arg_count < 2 else
         args[1]
     )
-    output_path: str = (
-        COMMON_CONFIG["default_output_path"]
+    output_path = (
+        Path(COMMON_CONFIG["default_output_path"]).resolve()
         if arg_count < 3 else
-        args[2].replace("\\", '/').rstrip("/")
+        Path(args[2]).expanduser().resolve()
     )
 
     verbose = COMMON_CONFIG["verbose"]
 
     # Check if given paths are valid:
-    if not os.path.isfile(path):
-        print(f"Error: Could not find file at {path !r}")
+    if not source_path.is_file():
+        print(f"Error: Could not find file at {args[0] !r}")
         exit(-1)
 
-    if not os.path.isdir(output_path):
-        print(f"Error: Output path is not a directory ({output_path !r})")
+    if not output_path.is_dir():
+        print(f"Error: Output path is not a directory ({str(output_path) !r})")
         exit(-1)
 
     # Build datapack
     with open(source_path, 'rt', encoding='utf-8') as mcs_file:
         code = mcs_file.read()
 
-    build_datapack(code, datapack_name, output_path, verbose, source_path=source_path)
+    build_datapack(code, datapack_name, str(output_path), verbose, source_path=source_path)
 
 
 def sh_config(*args) -> None:

--- a/npm/bin/mcs.js
+++ b/npm/bin/mcs.js
@@ -14,11 +14,13 @@ const candidates = [
 for (const [command, args] of candidates) {
   const result = spawnSync(command, args, { stdio: "inherit" });
 
-  if (result.error?.code === "ENOENT") {
+  if (result.error) {
     continue;
   }
 
-  process.exit(result.status ?? 1);
+  if (result.status != null) {
+    process.exit(result.status);
+  }
 }
 
 console.error(

--- a/npm/bin/mcs.js
+++ b/npm/bin/mcs.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("child_process");
+
+const mcsArgs = process.argv.slice(2);
+const pythonModuleArgs = ["-m", "minecraft_script", ...mcsArgs];
+
+const candidates = [
+  ["py", ["-3", ...pythonModuleArgs]],
+  ["python", pythonModuleArgs],
+  ["python3", pythonModuleArgs],
+];
+
+for (const [command, args] of candidates) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+
+  if (result.error?.code === "ENOENT") {
+    continue;
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+console.error(
+  "Minecraft Script requires Python 3.\n" +
+    "Install Python from https://www.python.org/downloads/ and run:\n" +
+    "  pip install minecraft-script"
+);
+process.exit(1);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "minecraft-script",
+  "version": "0.2.2",
+  "description": "Compile and debug Minecraft Script (.mcs) files into Minecraft datapacks",
+  "license": "MIT",
+  "type": "commonjs",
+  "bin": {
+    "mcs": "bin/mcs.js",
+    "minecraft-script": "bin/mcs.js"
+  },
+  "scripts": {
+    "postinstall": "node scripts/postinstall.js"
+  },
+  "files": [
+    "bin",
+    "scripts"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Bard-Gaming/Minecraft-Script.git",
+    "directory": "npm"
+  },
+  "homepage": "https://github.com/Bard-Gaming/Minecraft-Script#readme",
+  "bugs": {
+    "url": "https://github.com/Bard-Gaming/Minecraft-Script/issues"
+  },
+  "keywords": [
+    "minecraft",
+    "datapack",
+    "mcs",
+    "minecraft-script"
+  ]
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -20,12 +20,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Bard-Gaming/Minecraft-Script.git",
+    "url": "git+https://github.com/SpyC0der77/Minecraft-Script.git",
     "directory": "npm"
   },
-  "homepage": "https://github.com/Bard-Gaming/Minecraft-Script#readme",
+  "homepage": "https://github.com/SpyC0der77/Minecraft-Script#readme",
   "bugs": {
-    "url": "https://github.com/Bard-Gaming/Minecraft-Script/issues"
+    "url": "https://github.com/SpyC0der77/Minecraft-Script/issues"
   },
   "keywords": [
     "minecraft",

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -14,6 +14,8 @@ const candidates = [
   ["python3", ["-m", "pip", ...pipArgs]],
 ];
 
+let ranCandidate = false;
+
 for (const [command, args] of candidates) {
   const result = spawnSync(command, args, { stdio: "inherit" });
 
@@ -21,22 +23,30 @@ for (const [command, args] of candidates) {
     continue;
   }
 
+  ranCandidate = true;
+
   if (result.status === 0) {
     return;
   }
 
   if (result.status != null) {
-    console.warn(
-      "\n[minecraft-script] Failed to install the Python package via pip.\n" +
-        "Install it manually with:\n" +
-        `  pip install minecraft-script==${version}\n`
-    );
-    return;
+    continue;
   }
+}
+
+const manualInstall = `  pip install minecraft-script==${version}\n`;
+
+if (ranCandidate) {
+  console.warn(
+    "\n[minecraft-script] Failed to install the Python package via pip.\n" +
+      "Install it manually with:\n" +
+      manualInstall
+  );
+  return;
 }
 
 console.warn(
   "\n[minecraft-script] Python was not found, so the PyPI package was not installed.\n" +
     "Install Python 3 from https://www.python.org/downloads/ and run:\n" +
-    `  pip install minecraft-script==${version}\n`
+    manualInstall
 );

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -29,9 +29,7 @@ for (const [command, args] of candidates) {
     return;
   }
 
-  if (result.status != null) {
-    continue;
-  }
+  continue;
 }
 
 const manualInstall = `  pip install minecraft-script==${version}\n`;

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -1,0 +1,40 @@
+const { spawnSync } = require("child_process");
+const { readFileSync } = require("fs");
+const { join } = require("path");
+
+const packageJson = JSON.parse(
+  readFileSync(join(__dirname, "..", "package.json"), "utf8")
+);
+const version = packageJson.version;
+const pipArgs = ["install", `minecraft-script==${version}`];
+
+const candidates = [
+  ["py", ["-3", "-m", "pip", ...pipArgs]],
+  ["python", ["-m", "pip", ...pipArgs]],
+  ["python3", ["-m", "pip", ...pipArgs]],
+];
+
+for (const [command, args] of candidates) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+
+  if (result.error?.code === "ENOENT") {
+    continue;
+  }
+
+  if (result.status === 0) {
+    return;
+  }
+
+  console.warn(
+    "\n[minecraft-script] Failed to install the Python package via pip.\n" +
+      "Install it manually with:\n" +
+      `  pip install minecraft-script==${version}\n`
+  );
+  return;
+}
+
+console.warn(
+  "\n[minecraft-script] Python was not found, so the PyPI package was not installed.\n" +
+    "Install Python 3 from https://www.python.org/downloads/ and run:\n" +
+    `  pip install minecraft-script==${version}\n`
+);

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -17,7 +17,7 @@ const candidates = [
 for (const [command, args] of candidates) {
   const result = spawnSync(command, args, { stdio: "inherit" });
 
-  if (result.error?.code === "ENOENT") {
+  if (result.error) {
     continue;
   }
 
@@ -25,12 +25,14 @@ for (const [command, args] of candidates) {
     return;
   }
 
-  console.warn(
-    "\n[minecraft-script] Failed to install the Python package via pip.\n" +
-      "Install it manually with:\n" +
-      `  pip install minecraft-script==${version}\n`
-  );
-  return;
+  if (result.status != null) {
+    console.warn(
+      "\n[minecraft-script] Failed to install the Python package via pip.\n" +
+        "Install it manually with:\n" +
+        `  pip install minecraft-script==${version}\n`
+    );
+    return;
+  }
 }
 
 console.warn(

--- a/readme.md
+++ b/readme.md
@@ -83,4 +83,4 @@ Source code, documentation, and examples, can all be found on the GitHub.
 
 ## Compatibility
 
-This python package **does not work on Linux / macOS**.
+This Python package runs on **Windows**, **macOS**, and **Linux**. You can pass file paths in either relative or absolute form using your platform's native separators.

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,10 @@ python -m minecraft_script help
 
 If you want to simplify the usage of shell commands, you can check out [the installations page in the documentation](https://github.com/Bard-Gaming/Minecraft-Script/blob/main/documentation/custom-installations.md).
 
+### Configuration
+
+Use `config set default_output_path <path>` to change the default compile output directory. The path must already exist; `config set` validates it and stores the resolved absolute path in `config.json`. Existing relative values (such as the default `"."`) continue to work at compile time because `compile` resolves `default_output_path` again before use.
+
 ## GitHub
 
 **[Link to GitHub Repository](https://github.com/Bard-Gaming/Minecraft-Script)**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * minecraft-script released as an npm package providing `mcs`/`minecraft-script` CLI entrypoints
  * npm install now attempts to auto-install the matching Python package

* **Chores**
  * .gitignore updated to exclude build/output and local package artifacts

* **Documentation**
  * Added configuration docs for changing compile output path; clarified cross‑platform (Windows/macOS/Linux) support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->